### PR TITLE
Prevent Item Delection + Code Clean Up & Optimization

### DIFF
--- a/RestrictContainers.cs
+++ b/RestrictContainers.cs
@@ -56,6 +56,7 @@ namespace OdinsFoodBarrels
                 __result = false;
                 return __result;
             }
+
             return true;
         }
 

--- a/RestrictContainers.cs
+++ b/RestrictContainers.cs
@@ -9,31 +9,18 @@ namespace OdinsFoodBarrels
     ///     containers can only contain items of a single type.
     /// </summary>
     [HarmonyPatch(typeof(Inventory))]
-    internal class RestrictContainers
+    internal static class RestrictContainers
     {
         private static string? _loadingContainer;
         private static string? _targetContainer;
         private static HashSet<string>? _allowedItems;
         private static Dictionary<string, HashSet<string>> _allowedItemsByContainer = new();
 
-        private static RestrictContainers? _instance;
-
-        /// <summary>
-        ///     Singleton instance
-        /// </summary>
-        public static RestrictContainers Instance => _instance ??= new RestrictContainers();
-
-        /// <summary>
-        ///     Hide .ctor
-        /// </summary>
-        private RestrictContainers()
-        { }
-
         /// <summary>
         ///     Set which containers to restrict and which item is allowed to be placed in each one.
         /// </summary>
         /// <param name="allowedItemByContainer"></param>
-        public void SetContainerRestrictions(Dictionary<string, HashSet<string>> allowedItemByContainer)
+        public static void SetContainerRestrictions(Dictionary<string, HashSet<string>> allowedItemByContainer)
         {
             _allowedItemsByContainer = allowedItemByContainer;
         }
@@ -50,32 +37,6 @@ namespace OdinsFoodBarrels
         }
 
         /// <summary>
-        ///     Checks if adding item to inventory should be blocked based on
-        ///     if the container and item names are restricted. Also notifies
-        ///     the player of why adding the item is not allowed.
-        /// </summary>
-        /// <param name="inventory"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item)
-        {
-            if (inventory == null || item == null) { return false; }
-
-            if (IsRestrictedContainer(inventory.m_name, out HashSet<string> allowedItems))
-            {
-                var result = allowedItems.Contains(item.PrefabName());
-                if (!result)
-                {
-                    // Message player that item cannot be placed in container.
-                    var msg = $"{item.m_shared.m_name} cannnot be placed in {inventory.m_name}";
-                    Player.m_localPlayer?.Message(MessageHud.MessageType.Center, msg);
-                }
-                return result;
-            }
-            return true;
-        }
-
-        /// <summary>
         ///    Patch to trigger CanAddItem check when attempting to add item to inventory.
         ///    If CanAddItem is false then the AddItem method in Valheim will be skipped
         ///    and return false to indicate the item was not added.
@@ -86,30 +47,9 @@ namespace OdinsFoodBarrels
         /// <returns></returns>
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData) })]
-        [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_1(Inventory __instance, ItemDrop.ItemData item, ref bool __result)
-        {
-            if (!CanAddItem(__instance, item))
-            {
-                __result = false;
-                return __result;
-            }
-            return true;
-        }
-
-        /// <summary>
-        ///    Patch to trigger CanAddItem check when attempting to add item to inventory.
-        ///    If CanAddItem is false then the AddItem method in Valheim will be skipped
-        ///    and return false to indicate the item was not added.
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="item"></param>
-        /// <param name="__result"></param>
-        /// <returns></returns>
-        [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, ref bool __result)
+        private static bool AddItemPrefix(Inventory __instance, ItemDrop.ItemData item, ref bool __result)
         {
             if (!CanAddItem(__instance, item))
             {
@@ -131,22 +71,28 @@ namespace OdinsFoodBarrels
         /// <returns></returns>
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix_1(Inventory __0, ItemDrop.ItemData __1, Inventory __instance)
+        private static bool MoveItemToThisPrefix_1(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item)
         {
-            var fromInventory = __0;
-            var item = __1;
             if (__instance == null || fromInventory == null || item == null) { return false; }
+
+            Log.LogDebug("MoveItemToThisPrefix");
+            Log.LogDebug($"Add to: {__instance.m_name}");
+            Log.LogDebug($"Item: {item.PrefabName()}");
 
             return CanAddItem(__instance, item);
         }
 
+
         /// <summary>
-        ///     Patch to prevent MoveItemToThis from running if CanAddItem check is false. MoveItemToThis
-        ///     will call RemoveItem from the source inventory even in cases where AddItem returns false,
-        ///     so the entire method needs to be prevented from running to avoid items being lost when players
-        ///     try to place items in containers that do not allow that type of item.
+        ///     Patch to allow checking if the Container is being loaded
+        ///     from ZDO rather than altered by interacting in-game. Used
+        ///     to avoid restricted items being loaded and prevent deleting
+        ///     "non-allowed" items that had been put in the container when
+        ///     restrictions were not enabled.
         /// </summary>
+        /// <param name="__instance"></param>
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.Load))]
         private static void LoadPrefix(Inventory __instance)
@@ -186,8 +132,10 @@ namespace OdinsFoodBarrels
         private static void MoveAllPrefix(Inventory __instance, Inventory fromInventory)
         {
             if (__instance == null || fromInventory == null) { return; }
+
             Log.LogDebug("MoveAllPrefix");
             Log.LogDebug($"Move to: {__instance.m_name}");
+
             if (IsRestrictedContainer(__instance.m_name, out HashSet<string> allowedItems))
             {
                 _targetContainer = __instance.m_name;
@@ -216,25 +164,10 @@ namespace OdinsFoodBarrels
         /// <param name="item"></param>
         /// <returns></returns>
         [HarmonyPrefix]
-        [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData) })]
-        [HarmonyPriority(Priority.First)]
-        private static bool RemoveItemPrefix_1(Inventory __instance, ItemDrop.ItemData item)
-        {
-            return ShouldRemoveItem(__instance, item);
-        }
-
-        /// <summary>
-        ///     Patch to check trigger ShouldRemoveItem check and prevent RemoveItem from running if
-        ///     the item was moved during a call to MoveAll and failed to be added to the target
-        ///     container because it was restricted and not the allowed item type.
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData) })]
         [HarmonyPatch(nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool RemoveItemPrefix_2(Inventory __instance, ItemDrop.ItemData item)
+        private static bool RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item)
         {
             return ShouldRemoveItem(__instance, item);
         }
@@ -251,8 +184,27 @@ namespace OdinsFoodBarrels
         [HarmonyPatch(nameof(Inventory.RemoveOneItem), new[] { typeof(ItemDrop.ItemData) })]
         [HarmonyPriority(Priority.First)]
         private static bool RemoveOneItemPrefix(Inventory __instance, ItemDrop.ItemData item)
-            if (inventory.m_name == _loadingContainer)
         {
+            return ShouldRemoveItem(__instance, item);
+        }
+
+        /// <summary>
+        ///     Checks if adding item to inventory should be blocked based on
+        ///     if the container and item names are restricted. Also notifies
+        ///     the player of why adding the item is not allowed.
+        /// </summary>
+        /// <param name="inventory"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item)
+        {
+            if (inventory == null || item == null) { return false; }
+
+            // Return early if this check is being called while loading a container.
+            // Don't want to delete "non-allowed" items that were put in the container
+            // while the restrictions were disabled.
+            if (inventory.m_name == _loadingContainer)
+            {
                 return true;
             }
 
@@ -270,6 +222,7 @@ namespace OdinsFoodBarrels
 
             return true;
         }
+
 
         /// <summary>
         ///    Checks if the values for _targetContainer and _allowedItems were set during a
@@ -293,10 +246,12 @@ namespace OdinsFoodBarrels
             Log.LogDebug("RemoveItemPrefix");
             Log.LogDebug($"Remove from: {__instance.m_name}");
             Log.LogDebug($"Item: {item.PrefabName()}");
+
             if (wasAddedToDynamicPile && _allowedItems != null)
             {
                 return _allowedItems.Contains(item.PrefabName());
             }
+
             return true;
         }
     }

--- a/RestrictContainers.cs
+++ b/RestrictContainers.cs
@@ -65,9 +65,9 @@ namespace OdinsFoodBarrels
         ///     so the entire method needs to be prevented from running to avoid items being lost when players
         ///     try to place items in containers that do not allow that type of item.
         /// </summary>
-        /// <param name="__0"></param>
-        /// <param name="__1"></param>
         /// <param name="__instance"></param>
+        /// <param name="fromInventory"></param>
+        /// <param name="item"></param>
         /// <returns></returns>
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]


### PR DESCRIPTION
Added a check so that if somehow a user gets a non-allowed item in one of the containers (I don't know how they would aside from updating the mod from before it restricted items) the item won't get deleted next time they load into the game.

Also cleaned up the code a bit and gave it a very mild increase in performance. 